### PR TITLE
Remove layout indicators in non editable mode.

### DIFF
--- a/plonetheme/onegovbear/resources.zcml
+++ b/plonetheme/onegovbear/resources.zcml
@@ -33,6 +33,7 @@
         <theme:scss file="theme/scss/controlpanel.scss" />
         <theme:scss file="theme/scss/login.scss" />
         <theme:scss file="theme/scss/sitemap.scss" />
+        <theme:scss file="theme/scss/simplelayout.scss" />
     </theme:resources>
 
 </configure>

--- a/plonetheme/onegovbear/theme/scss/simplelayout.scss
+++ b/plonetheme/onegovbear/theme/scss/simplelayout.scss
@@ -1,0 +1,54 @@
+$toolbar-bg-color: $gray-darker;
+$action-bg-color: $gray-dark;
+$action-bg-color-hover: $gray-light;
+
+$column-bg-color: $gray-light;
+
+$block-placeholder-bg-color: lighten($gray-light, 10%);
+$block-placeholder-border-size: 1px;
+$block-placeholder-border-style: dotted;
+$block-placeholder-border-color: darken($gray-light, 10%);
+
+$layout-placeholder-bg-color: $block-placeholder-bg-color;
+$layout-placeholder-border-size: $block-placeholder-border-size;
+$layout-placeholder-border-style: $block-placeholder-border-style;
+$layout-placeholder-border-color: $block-placeholder-border-color;
+
+ul[class^="sl-toolbar"] {
+  border-radius: $border-radius;
+  background-color: $toolbar-bg-color;
+}
+
+.sl-block {
+  box-shadow: none;
+  .sl-block-content {
+    img {
+      max-width: 100%;
+    }
+  }
+}
+
+.sl-column {
+  background-color: $content-bg-color;
+}
+
+.sl-layout {
+  .block-placeholder {
+    background-color: $block-placeholder-bg-color;
+    border: $block-placeholder-border-size $block-placeholder-border-style $block-placeholder-border-color;
+  }
+}
+
+.sl-simplelayout {
+  .layout-placeholder {
+    background-color: $layout-placeholder-bg-color;
+    border: $layout-placeholder-border-size $layout-placeholder-border-style $layout-placeholder-border-color;
+  }
+}
+
+// If user is permitted to edit the simplelayout page
+.documentEditable {
+  .sl-column {
+    background-color: $column-bg-color;
+  }
+}


### PR DESCRIPTION
Fixes 4teamwork/bern.web#159

When the user is not permitted to edit the page the simplelayout is not
loaded as well the user user should not see the layout indicators. So
remove the stylings for the layout indicators when
`documentEditable` class is present.

When permitted to edit:
![simplelayout_editable](https://cloud.githubusercontent.com/assets/1637820/8354173/2ee2796e-1b46-11e5-86be-2cca7405b903.png)

When user has no permissions:
![simplelayout](https://cloud.githubusercontent.com/assets/1637820/8354176/36580574-1b46-11e5-826f-c144aea80f35.png)

> The doubled toolbox on the screen is done through the capturing tool.
