### PR TITLE
Block placeholder is not visible.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/simplelayout.scss
+++ b/plonetheme/onegovbear/theme/scss/simplelayout.scss
@@ -2,12 +2,12 @@ $toolbar-bg-color: $gray-darker;
 $action-bg-color: $gray-dark;
 $action-bg-color-hover: $gray-light;
 
-$column-bg-color: $gray-light;
+$column-bg-color: $gray;
 
-$block-placeholder-bg-color: lighten($gray-light, 10%);
+$block-placeholder-bg-color: $gray-light;
 $block-placeholder-border-size: 1px;
 $block-placeholder-border-style: dotted;
-$block-placeholder-border-color: darken($gray-light, 10%);
+$block-placeholder-border-color: $gray-dark;
 
 $layout-placeholder-bg-color: $block-placeholder-bg-color;
 $layout-placeholder-border-size: $block-placeholder-border-size;
@@ -21,15 +21,22 @@ ul[class^="sl-toolbar"] {
 
 .sl-block {
   box-shadow: none;
+  margin-bottom: 2px;
   .sl-block-content {
     img {
       max-width: 100%;
     }
   }
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .sl-column {
   background-color: $content-bg-color;
+  .block-placeholder {
+    margin-bottom: 1px;
+  }
 }
 
 .sl-layout {


### PR DESCRIPTION
Fixes 4teamwork/bern.web#167

Use colors with more contrast. Set more spacing for placeholder so the
border is visible.

Examples with bern.web policy.

Static:

![bildschirmfoto 2015-06-29 um 17 12 11](https://cloud.githubusercontent.com/assets/1637820/8411151/b0137026-1e82-11e5-8452-cedd6c1bfc9e.png)

Dragging:

![bildschirmfoto 2015-06-29 um 17 12 32](https://cloud.githubusercontent.com/assets/1637820/8411155/b819b474-1e82-11e5-9f70-0717e707b791.png)
