### PR TITLE
Pathbar displays border on the bottom in ie10

### DIFF
--- a/plonetheme/onegovbear/theme/scss/pathbar.scss
+++ b/plonetheme/onegovbear/theme/scss/pathbar.scss
@@ -16,7 +16,7 @@ $pathbar-text-color: $text-color;
     float:left;
     background-color: $pathbar-bg-color;
     > span {
-      padding: 6px 5px 8px 5px;
+      padding: 6px 8px;
       display:inline-block;
       > a {
         color: $pathbar-text-color;


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/194

The padding was overlapping the parent element.

![bildschirmfoto 2015-07-10 um 16 51 43](https://cloud.githubusercontent.com/assets/1637820/8621123/2a738d52-2724-11e5-84f7-11e1ab3a5c43.png)
