### PR TITLE
Pathbar is not displayed properly in ie10.

### DIFF
--- a/plonetheme/onegovbear/theme/images/pathbar_separator.svg
+++ b/plonetheme/onegovbear/theme/images/pathbar_separator.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 149 250.7" style="enable-background:new 0 0 149 250.7;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<polygon id="XMLID_7_" class="st0" points="17.8,0 0,0 0,0.2 131,125.5 0.1,250.7 18.1,250.7 149,125.5 "/>
+</svg>

--- a/plonetheme/onegovbear/theme/scss/pathbar.scss
+++ b/plonetheme/onegovbear/theme/scss/pathbar.scss
@@ -14,58 +14,35 @@ $pathbar-font-weight: normal !default;
 
   #portal-breadcrumbs {
     width: 100%;
-    float:left;
     background-color: $pathbar-bg-color;
+    @include clearfix();
     > span {
-      padding: 6px 0;
-      display:inline-block;
-      &:first-child {
-        padding: 6px 0 6px 8px;
-      }
+      float: left;
       > a {
+        display: block;
         color: $pathbar-text-color;
-        padding-right: 30px;
+        padding: 6px;
         font-weight: $pathbar-font-weight;
         font-size: $font-size-small;
+        float: left;
       }
       // White separator between pathbar lines
       &:before {
         content: "";
-        height: 0;
         position: absolute;
-        background-color: $pathbar-arrow-color;
+        background-color: #fff;
         left: 0;
         right: 0;
-        margin-top: 24px;
+        height: 2px;
+        margin-top: -1px;
       }
       > .breadcrumbSeparator {
-        padding-left: 0;
-        position: relative;
-        display: inline-block;
-        // White triangle for border
-        &:before {
-          content: "";
-          width: 0;
-          height: 0;
-          border-style: solid;
-          border-width: 17px 23px;
-          border-color: transparent transparent transparent #fff;
-          position: absolute;
-          top: -23px;
-          right: -18px;
-        }
-        // Grey triangle for separator
-        &:after {
-          content: "";
-          width: 0;
-          height: 0;
-          border-style: solid;
-          border-width: 18px 24px;
-          border-color: transparent transparent transparent $pathbar-bg-color;
-          position: absolute;
-          top: -24px;
-          right: -17px;
-        }
+        display: block;
+        float: left;
+        width: 18px;
+        height: 31px;
+        background-image: url("++theme++plonetheme.onegovbear/images/pathbar_separator.svg");
+        background-repeat: no-repeat;
       }
     }
   }


### PR DESCRIPTION
Fixes 4teamwork/bern.web#300

Use background image for displaying the triange. Using absolute
positioning with pseudo elements seems not to work in ie10. So for
preventing further problems with positioning use an image.

Chrome:
![bildschirmfoto 2015-07-31 um 13 33 47](https://cloud.githubusercontent.com/assets/1637820/9006547/ce07b9f6-3788-11e5-8079-a8a199549ae2.png)
IE10:
![bildschirmfoto 2015-07-31 um 11 18 27](https://cloud.githubusercontent.com/assets/1637820/9006544/b9d4e9cc-3788-11e5-99fc-f8210c41f46e.png)
