### PR TITLE
load style.top inline CSS nodes early.

### DIFF
--- a/plonetheme/onegovbear/theme/rules.xml
+++ b/plonetheme/onegovbear/theme/rules.xml
@@ -26,9 +26,13 @@
     <after content="/html/head/base | /html/head/comment()" theme-children="/html/head" />
 
     <!-- CSS:
+         - Insert style.top-nodes at the very top, allowing to early-load custom
+           inline CSS.
          - Make sure link / style tags are before script tags (parallel downloading)
          - Move #portal-top link / style tags to the head before script tags
     -->
+    <after theme-children="/html/head" css:content="html > head > style.top"  />
+    <after theme-children="/html/head" css:content="#portal-top style.top"/>
     <after content="/html/head/link | /html/head/style" theme-children="/html/head" />
     <after theme-children="/html/head" css:content="#portal-top link"/>
     <after theme-children="/html/head" css:content="#portal-top style"/>


### PR DESCRIPTION
By moving style.top nodes before other link / style / script nodes, the inline CSS of those nodes is rendered early.
This helps us to avoid flickering of certain components, such as background images, by inlining the CSS and caching the resources in the browser.

The style-tag needs to have the "top" class, so that we do not mess with the order of other inlined resources by accident.
