### PR TITLE
Safari and ie10 displays border under each navigation point.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/globalnav.scss
+++ b/plonetheme/onegovbear/theme/scss/globalnav.scss
@@ -26,17 +26,21 @@ $globalnav-link-font-weight: normal !default;
     margin: 0;
     padding: 0;
     width: 100%;
+    @include clearfix();
 
     > li {
+      display: block;
+      float: left;
       > a {
         color: $globalnav-link-color;
         font-weight: $globalnav-link-font-weight;
-        display: inline-block;
-        padding: 1em;
+        display: block;
+        padding: 16px;
         margin: 0;
         border-right: $globalnav-separator-width solid $globalnav-separator-color;
         text-transform: uppercase;
         font-size: $globalnav-font-size;
+        height: 20px;
         @include transition(background-color 100ms);
         &.open {
           color: $globalnav-link-color-hover;


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/297

Depends on https://github.com/4teamwork/bern.web/pull/310

Because of diffrent calculating of line-height predefined from the body
the navigation elements does not have equal height. So use display block
to get rid of this influence. Because of the same reason use px
instead of em for setting padding on navigation elements. Set fixed
height to make it displayed equal for each browser.
