### PR TITLE
highlight broken links.

### DIFF
--- a/plonetheme/onegovbear/theme/rules.xml
+++ b/plonetheme/onegovbear/theme/rules.xml
@@ -114,5 +114,15 @@
     <after content="//*[@id='portal-footer-wrapper']/div/script" css:theme="#container" />
     <after content="//*[@id='portal-footer-wrapper']/div/noscript" css:theme="#container" />
 
+    <rules css:if-content="body.userrole-authenticated">
+        <replace content="//a[contains(@href, 'resolveuid')]">
+            <xsl:copy>
+                <xsl:copy-of select="@*" />
+                <xsl:attribute name="class"><xsl:value-of select="@class" /> broken-link</xsl:attribute>
+                <xsl:apply-templates />
+            </xsl:copy>
+        </replace>
+    </rules>
+
   </rules>
 </rules>

--- a/plonetheme/onegovbear/theme/scss/content.scss
+++ b/plonetheme/onegovbear/theme/scss/content.scss
@@ -1,7 +1,9 @@
 $text-color-light: desaturate(lighten($text-color, 25%), 100%) !default;
+$mark-broken-links: true !default;
 
 @include declare-variables(
-  text-color-light);
+  text-color-light,
+  mark-broken-links);
 
 a,
 :link,
@@ -80,5 +82,17 @@ dl.collapsible {
   }
   a {
     @include label($primary-color);
+  }
+}
+
+
+@if $mark-broken-links {
+  a.broken-link {
+    outline: 2px dotted $danger-color;
+    @extend .fa-icon;
+    @extend .fa-exclamation-triangle;
+    &:before {
+      color: $danger-color;
+    }
   }
 }


### PR DESCRIPTION
Hightlights broken links with an outline and an exclamation mark icon.
Links are only highlighted for authenticated users.
The highlighting can be desabled with

``` scss
   $mark-broken-links: false;
```

<img width="591" alt="bildschirmfoto 2015-08-05 um 11 49 56" src="https://cloud.githubusercontent.com/assets/7469/9083006/23c3e864-3b68-11e5-98a8-a4ac6a5d2e37.png">
