### PR TITLE
Mobilebuttons looks bad with subsite logo.

### DIFF
--- a/plonetheme/onegovbear/theme/index.html
+++ b/plonetheme/onegovbear/theme/index.html
@@ -19,7 +19,17 @@
   <body>
     <p id="accesskeys" class="hiddenStructure" />
     <div id="portal-top">
-
+      <ul class="mobileButtons">
+        <li>
+          <a href="#" id="toggle_search" title=""></a>
+        </li>
+        <li>
+          <a href="#" id="toggle_slidenavi" title=""></a>
+        </li>
+        <li>
+          <a href="#" id="toggle_subsitelangs" title="">de</a>
+        </li>
+      </ul>
       <div id="portal-personaltools-wrapper">
         <dl class="actionMenu deactivated" id="portal-personaltools"><dt id="anon-personalbar">
           <a href="#" id="personaltools-a">Kontakt</a>
@@ -60,18 +70,6 @@
       <div id="page-wrapper" class="clearfix">
 
         <div id="header" class="clearfix">
-          <ul class="mobileButtons">
-            <li>
-              <a href="#" id="toggle_search" title=""></a>
-            </li>
-            <li>
-              <a href="#" id="toggle_slidenavi" title=""></a>
-            </li>
-            <li>
-              <a href="#" id="toggle_subsitelangs" title="">de</a>
-            </li>
-          </ul>
-
           <div class="row logoRow">
             <div class="cell">
               <a id="portal-logo" href="#"><img src="images/logo_onegov.png" alt="" /></a>

--- a/plonetheme/onegovbear/theme/scss/additionallogo.scss
+++ b/plonetheme/onegovbear/theme/scss/additionallogo.scss
@@ -1,28 +1,17 @@
 #additional-logo {
-  right: 0;
-  float:right;
-  position: absolute;
-  margin-top: 1em;
-  top: 50px;
+
+  vertical-align: top;
+  text-align: right;
+  display: table-cell;
 
   img {
-    height: 50px;
+    max-height: 50px;
     width: auto;
 
     @include screen-small {
-      height: auto;
+      max-height: none;
       width: auto;
     }
   }
 
-  @include screen-small {
-    position: relative;
-    top:0;
-    margin-top: 0;
-  }
-
-  @include screen-medium {
-    margin: 2em 0 2em 0;
-    position: relative;
-  }
 }

--- a/plonetheme/onegovbear/theme/scss/layout.scss
+++ b/plonetheme/onegovbear/theme/scss/layout.scss
@@ -36,17 +36,27 @@ body {
     width: 100%;
   }
 
-  #portal-logo {
-    display: inline-block;
-    margin-top: 1em;
-    position: absolute;
-
-    @include screen-small {
-      margin-top: 0;
+  .logoRow {
+    padding: 10px 5px;
+    box-sizing: border-box;
+    @include screen-large {
+      padding: 30px 0;
     }
-    @include screen-medium {
-      margin: 2em 0 2em 0;
-      position: relative;
+    > .cell {
+      display: table;
+    }
+  }
+
+  #portal-logo {
+    display: table-cell;
+    vertical-align: top;
+    text-align: left;
+    img {
+      max-height: 50px;
+      width: auto;
+      @include screen-small {
+        max-height: none;
+      }
     }
   }
 }

--- a/plonetheme/onegovbear/theme/scss/portaltop.scss
+++ b/plonetheme/onegovbear/theme/scss/portaltop.scss
@@ -5,15 +5,15 @@ $portal-top-bg-color: $page-bg-color !default;
 
 
 #portal-top {
-  height: 0;
+  padding: 0;
 
-  @include screen-medium {
-    height: auto;
+  @include screen-large {
+    padding: 0.25em 0;
   }
+
   background-color: $portal-top-bg-color;
   max-width: $page-wrapper-width;
   margin: 0 auto;
-  padding: 0.25em 0;
   position: relative;
   font-size: $font-size-small;
   @include clearfix();


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/343

Depends on https://github.com/4teamwork/bern.web/pull/350

Move mobilebuttons to top and make them full width.
Use table layout for less complexity.
Move subsite icon styles.

Large:
![mob_nav_large](https://cloud.githubusercontent.com/assets/1637820/9171661/cf56cd50-3f6d-11e5-964b-355504c1c7f8.png)
Middle:
![mob_nav_middle](https://cloud.githubusercontent.com/assets/1637820/9171662/cf70bb3e-3f6d-11e5-9708-b07fb1899bae.png)
Small
![mob_nav_small](https://cloud.githubusercontent.com/assets/1637820/9171663/cf7afca2-3f6d-11e5-9cde-5389a7b6d503.png)
Tiny
![mob_nav_tiny](https://cloud.githubusercontent.com/assets/1637820/9171664/cf7e3548-3f6d-11e5-95dc-d6d954980974.png)
