### PR TITLE
Logo takes fullwidth in header.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/additionallogo.scss
+++ b/plonetheme/onegovbear/theme/scss/additionallogo.scss
@@ -1,8 +1,6 @@
 #additional-logo {
 
-  vertical-align: top;
-  text-align: right;
-  display: table-cell;
+  float: right;
 
   img {
     max-height: 50px;

--- a/plonetheme/onegovbear/theme/scss/layout.scss
+++ b/plonetheme/onegovbear/theme/scss/layout.scss
@@ -48,9 +48,6 @@ body {
   }
 
   #portal-logo {
-    display: table-cell;
-    vertical-align: top;
-    text-align: left;
     img {
       max-height: 50px;
       width: auto;


### PR DESCRIPTION
Clicking on the backgroundimage should no trigger a click on the logo.
Use float instead of tablelayout to get rid of the full width for logo
in the header.

Before:
![bildschirmfoto 2015-08-12 um 08 37 17](https://cloud.githubusercontent.com/assets/1637820/9217892/69544864-40cd-11e5-8bdd-a54b8fa65979.png)

After:
![bildschirmfoto 2015-08-12 um 08 38 54](https://cloud.githubusercontent.com/assets/1637820/9217909/980ab594-40cd-11e5-9dc4-92cac7c0e34e.png)
