### PR TITLE
Search box is aligned with absolute positioning.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/globalnav.scss
+++ b/plonetheme/onegovbear/theme/scss/globalnav.scss
@@ -19,6 +19,8 @@ $globalnav-link-font-weight: normal !default;
 
 #portal-globalnav-wrapper {
   margin-right: 0;
+  float: left;
+  width: 100%;
   @include noselect();
   #portal-globalnav {
     display: none;
@@ -26,8 +28,10 @@ $globalnav-link-font-weight: normal !default;
     background-color: $globalnav-bg-color;
     margin: 0;
     padding: 0;
-    width: 100%;
     @include clearfix();
+    @include screen-large {
+      margin-right: 315px;
+    }
 
     > li {
       display: block;
@@ -59,8 +63,5 @@ $globalnav-link-font-weight: normal !default;
     @include screen-large {
       display: block;
     }
-  }
-  @include screen-large {
-    margin-right: 315px;
   }
 }

--- a/plonetheme/onegovbear/theme/scss/search.scss
+++ b/plonetheme/onegovbear/theme/scss/search.scss
@@ -3,34 +3,42 @@ $searchbox-liveresults-hover-bg-color: darken($menu-bg-color, 5%) !default;
 $searchbox-liveresults-border-color: darken($menu-bg-color, 20%) !default;
 $searchbox-liveresults-border-radius: 5px !default;
 $search-highlight-bg-color: change-color($secondary-color, $lightness:70%, $saturation:90%);
+$searchbox-width: 295px;
 
 @include declare-variables(
   searchbox-liveresults-bg-color,
   searchbox-liveresults-hover-bg-color,
   searchbox-liveresults-border-color,
-  searchbox-liveresults-border-radius);
+  searchbox-liveresults-border-radius,
+  $searchbox-width);
 
 
 .portal-searchbox-wrapper{
-  float: none;
-  position: relative;
-  top: 0;
 
-  @include screen-medium {
-    top: -52px;
-  }
+  float: left;
+  width: $searchbox-width;
+  padding: 6px;
+  box-sizing: border-box;
+  margin-left: -$searchbox-width;
+  display: none;
+  z-index: 1;
+  right: 0;
 
   @include screen-large {
-    float: right;
+    display: block;
+    &.open {
+      position: static !important;
+      margin-left: -$searchbox-width !important;
+    }
   }
 
+  &.open {
+    display: block;
+    position: absolute;
+    margin-left: 0;
+  }
 
   #portal-searchbox {
-    display: none;
-
-    @include screen-large {
-      display: block;
-    }
 
     .searchSection {
       display: none;
@@ -41,30 +49,28 @@ $search-highlight-bg-color: change-color($secondary-color, $lightness:70%, $satu
     }
 
     & #searchGadget {
-      width: 85px;
+      width: 135px;
       padding: .5em 35px .5em .5em;
-      position: absolute;
-      right: 0.55em;
-      z-index: 2;
+      float: right;
+      box-sizing: border-box;
       &:focus{
-          width: 221px;
+          width: 100%;
       }
     }
 
     .LSBox {
+      @include clearfix();
       position: relative;
-      top: 5px;
-      height: 0;
       &:before {
           font-family: FontAwesome;
           content: "\f002";
           position: absolute;
           z-index: 3;
-          right: 10px;
-          top: 6px;
+          right: 12px;
+          top: 12px;
           font-size: 14px;
-          padding: 6px 15px 6px 5px;
           background-color: transparent;
+          visibility: visible;
       }
       input[type="text"] {
         line-height: 20px;


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/354

Depends on https://github.com/4teamwork/bern.web/pull/379

Use floating layout instead of absolute positioning.
Use gradient for displaying the bern logo on the right.

@jone We could use a mixin for the gradient. A good one is the compass mixing http://compass-style.org/examples/compass/css3/gradient/
