### PR TITLE
Delete overlay is too large.

### DIFF
--- a/plonetheme/onegovbear/resources.zcml
+++ b/plonetheme/onegovbear/resources.zcml
@@ -41,6 +41,7 @@
         <theme:scss file="theme/scss/additionallogo.scss" />
         <theme:scss file="theme/scss/languageselector.scss" />
         <theme:scss file="theme/scss/plonebrowser.scss" />
+        <theme:scss file="theme/scss/overlay.scss" />
 
         <theme:scss file="theme/scss/iconset.scss"
                     slot="bottom"

--- a/plonetheme/onegovbear/theme/scss/login.scss
+++ b/plonetheme/onegovbear/theme/scss/login.scss
@@ -1,13 +1,3 @@
-.overlay-login {
-  width: 600px !important;
-  left: 0 !important;
-  right: 0 !important;
-  margin-left: auto !important;
-  margin-right: auto !important;
-  top: 100px !important;
-  bottom: auto !important;
-}
-
 #login-form {
   margin-bottom: 1em;
 

--- a/plonetheme/onegovbear/theme/scss/overlay.scss
+++ b/plonetheme/onegovbear/theme/scss/overlay.scss
@@ -1,0 +1,17 @@
+.overlay-login {
+  width: 600px !important;
+  height: 320px !important;
+  left: 50% !important;
+  margin-left: -300px;
+  top: 50% !important;
+  margin-top: -280px;
+}
+
+.overlay-delete {
+  width: 600px !important;
+  height: 320px !important;
+  left: 50% !important;
+  margin-left: -300px;
+  top: 50% !important;
+  margin-top: -280px;
+}


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/363

Depends on https://github.com/4teamwork/ftw.simplelayout/pull/210

Make custom styles for delete overlay.
Move overlay styles to separate file.

![bildschirmfoto 2015-08-12 um 12 10 38](https://cloud.githubusercontent.com/assets/1637820/9221526/4a7c0166-40eb-11e5-96fa-113ce1529433.png)
