### PR TITLE
drop ftw.subsite / plone.app.widgets dependency.

### DIFF
--- a/plonetheme/onegovbear/testing.py
+++ b/plonetheme/onegovbear/testing.py
@@ -7,7 +7,6 @@ from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
 from zope.configuration import xmlconfig
-import ftw.subsite.tests.builders
 
 
 class ThemeLayer(PloneSandboxLayer):
@@ -24,11 +23,9 @@ class ThemeLayer(PloneSandboxLayer):
             context=configurationContext)
 
         z2.installProduct(app, 'ftw.simplelayout')
-        z2.installProduct(app, 'ftw.subsite')
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'plonetheme.onegovbear:default')
-        applyProfile(portal, 'ftw.subsite:default')
 
 
 THEME_FIXTURE = ThemeLayer()

--- a/plonetheme/onegovbear/tests/test_custom_scss_variables.py
+++ b/plonetheme/onegovbear/tests/test_custom_scss_variables.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from plone.app.layout.navigation.interfaces import INavigationRoot
 from plonetheme.onegovbear.browser.dynamic_scss_resources import custom_design_variables_resource_factory
 from plonetheme.onegovbear.browser.forms import VARIABLES_ANNOTATION_KEY
 from plonetheme.onegovbear.tests import FunctionalTestCase
@@ -41,7 +42,7 @@ class TestCustomSCSSVariables(FunctionalTestCase):
             '$globalnav-bg-color': 'fuchsia',
         }).save()
 
-        page = create(Builder('subsite').titled(u'My Subsite'))
+        page = create(Builder('folder').titled(u'My Subsite').providing(INavigationRoot))
         browser.visit(page, view='customize-design')
         browser.fill({
             '$secondary-color': 'green',
@@ -55,7 +56,8 @@ class TestCustomSCSSVariables(FunctionalTestCase):
             scss_resource.get_source(page, self.request)
         )
 
-        page2 = create(Builder('subsite').titled(u'My Subsite').within(page))
+        page2 = create(Builder('folder').titled(u'My Subsite').within(page)
+                       .providing(INavigationRoot))
         browser.visit(page2, view='customize-design')
         browser.fill({
             '$primary-color': 'yellow',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ version = '1.0.0.dev0'
 
 tests_require = [
     'ftw.builder',
-    'ftw.subsite',
     'ftw.testbrowser',
     'plone.app.testing',
     ]
@@ -41,7 +40,6 @@ setup(name='plonetheme.onegovbear',
           'ftw.upgrade',
           'plone.directives.form',
           'plone.app.theming',
-          'plone.app.widgets',
           'setuptools',
       ],
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -4,5 +4,4 @@ extensions += mr.developer
 
 auto-checkout =
     ftw.theming
-    ftw.subsite
     ftw.simplelayout


### PR DESCRIPTION
We dont want to have a dependency to plone.app.widgets (which is a dependency of ftw.subsite).
Lets use `INavigationRoot` instead of real subsites; the theme should not require ftw.subsite anyway.

/cc @mbaechtold 
