### PR TITLE
Formactions not clickable with huge forms.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/form.scss
+++ b/plonetheme/onegovbear/theme/scss/form.scss
@@ -25,6 +25,7 @@ $input-error-border-color: transparentize($danger-color, .5) !default;
   padding: 0.5em;
   width: 20em;
   outline: none;
+  box-sizing: border-box;
 
   border: 1px solid $input-border-color;
   @include borderradius();

--- a/plonetheme/onegovbear/theme/scss/overlays.scss
+++ b/plonetheme/onegovbear/theme/scss/overlays.scss
@@ -35,14 +35,15 @@ $overlay-close-mask-color: transparentize($gray-light, .2) !default;
   padding: 0.3em;
   @include boxsizing(border-box);
   @include boxshadow(0.1em 0.1em 1em 0 $gray-dark);
-  @include borderradius(10px);
+  @include borderradius-top-left(10px);
+  @include borderradius-top-right(10px);
   z-index: 1000 !important;
 
   position: fixed !important;
   width: auto !important;
   height: auto !important;
   top: 20px !important;
-  bottom: 30px !important;
+  bottom: 100px !important;
   right: 10% !important;
   left: 10% !important;
 
@@ -58,12 +59,21 @@ $overlay-close-mask-color: transparentize($gray-light, .2) !default;
     @include boxsizing(border-box);
     overflow: auto;
     padding: 1em;
+    padding-bottom: 0;
     height: 100%;
     width: 100%;
   }
 
   .formControls {
-    margin-top: 1em;
+    position: absolute;
+    bottom: -58px;
+    left: 0;
+    padding: 0 20px 10px 20px;
+    box-sizing: border-box;
+    background-color: #fff;
+    border-bottom-right-radius: 10px;
+    border-bottom-left-radius: 10px;
+    right: 0;
   }
 
   div.close {


### PR DESCRIPTION
Make formactions sticky on overlaybottom.
Use borderbox model for all input types for preventing horizontal
overflow.
