### PR TITLE
The overlay is too big in large screens.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/overlays.scss
+++ b/plonetheme/onegovbear/theme/scss/overlays.scss
@@ -47,8 +47,23 @@ $overlay-close-mask-color: transparentize($gray-light, .2) !default;
   height: auto !important;
   top: 20px !important;
   bottom: 100px !important;
-  right: 10% !important;
-  left: 10% !important;
+  right: 0 !important;
+  left: 0 !important;
+
+  @include screen-small {
+    right: 5% !important;
+    left: 5% !important;
+  }
+
+  @include screen-medium {
+    right: 15% !important;
+    left: 15% !important;
+  }
+
+  @include screen-large {
+    right: 20% !important;
+    left: 20% !important;
+  }
 
   &.contenttreeWindow {
     padding: 2em;


### PR DESCRIPTION
Use predefined breakpoints for dynamically setting the overlay width.
