### PR TITLE
Mapblock is not loading in an overlay.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/overlays.scss
+++ b/plonetheme/onegovbear/theme/scss/overlays.scss
@@ -33,7 +33,6 @@ $overlay-close-mask-color: transparentize($gray-light, .2) !default;
 }
 
 .overlay, .contenttreeWindow {
-  display: none;
   background-color: $content-bg-color;
   padding: 0.3em;
   @include boxsizing(border-box);


### PR DESCRIPTION
Fixes https://github.com/4teamwork/ftw.simplelayout/issues/229

Because the overlay is not visible initially the map can not set its
size. Because we have no animations anyway remove the `display: none;`
definition.
