### PR TITLE
Move dynamic resources up.

### DIFF
--- a/plonetheme/onegovbear/browser/dynamic_scss_resources.py
+++ b/plonetheme/onegovbear/browser/dynamic_scss_resources.py
@@ -66,5 +66,6 @@ class CustomDesignVariablesSCSSResource(DynamicSCSSResource):
 def custom_design_variables_resource_factory(context, request):
     return CustomDesignVariablesSCSSResource(
         'plonetheme.onegovbear.custom_design_variables.scss',
-        slot='addon',
+        slot='variables',
+        before='ftw.theming:portal_url',
     )


### PR DESCRIPTION
This is needed because these variables need to be defined before the policy resources are processed. This allows the policy to make use of the variables defined dynamically.
