### PR TITLE
Fix servicenavigation display issue in FF and IE9

### DIFF
--- a/plonetheme/onegovbear/theme/scss/layout.scss
+++ b/plonetheme/onegovbear/theme/scss/layout.scss
@@ -27,6 +27,7 @@ body {
   max-width: $page-wrapper-width;
   margin: 0 auto;
   margin-bottom: 1em;
+  overflow: hidden;
 }
 
 #header {


### PR DESCRIPTION
@maethu 

Fix FF and IE9 issue: bad margin on the servicenavigation:

before (left: FF bad, right: Chrome ok)

![bildschirmfoto 2015-09-01 um 14 58 15](https://cloud.githubusercontent.com/assets/557005/9605679/6062dde0-50bf-11e5-9df4-754f06e0420a.png)

after (left: FF, right ok: Chrome ok)

![bildschirmfoto 2015-09-01 um 14 58 28](https://cloud.githubusercontent.com/assets/557005/9605687/74a1c690-50bf-11e5-8b82-9e22e65356ee.png)
