### PR TITLE
Remove sidebar on folder_contents-view

### DIFF
--- a/plonetheme/onegovbear/theme/scss/portlets.scss
+++ b/plonetheme/onegovbear/theme/scss/portlets.scss
@@ -4,6 +4,10 @@ $portlet-column-bg-color: $gray-lighter !default;
   portlet-column-bg-color);
 
 
+.template-folder_contents.has-sidebar-column #column-sidebar {
+  display: none;
+}
+
 
 #column-navigation, #column-sidebar {
 


### PR DESCRIPTION
@maethu 

Removes right column on folder_contents

before:

![bildschirmfoto 2015-09-25 um 15 34 04](https://cloud.githubusercontent.com/assets/557005/10101827/51b922d8-639b-11e5-9216-7ff38b0ff96f.png)

after: 

![bildschirmfoto 2015-09-25 um 15 34 16](https://cloud.githubusercontent.com/assets/557005/10101828/53cd5cb0-639b-11e5-9da2-7db8a0adbb62.png)
