### PR TITLE
livesearch results: remove line break after icon.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/search.scss
+++ b/plonetheme/onegovbear/theme/scss/search.scss
@@ -114,7 +114,6 @@ $searchbox-width: 295px;
           }
 
           > * {
-            display: block;
             padding: 0;
             background: transparent;
           }


### PR DESCRIPTION
Remove line-break between icon and title-link in livesearch results.

**Before**
<img width="1624" alt="bildschirmfoto 2015-09-29 um 18 50 51" src="https://cloud.githubusercontent.com/assets/7469/10171586/2bc296c0-66db-11e5-903f-96b1d8d73a8f.png">
## 

**After**
<img width="1624" alt="bildschirmfoto 2015-09-29 um 18 51 01" src="https://cloud.githubusercontent.com/assets/7469/10171587/2bc5057c-66db-11e5-909e-2d73dfab0ad0.png">
