### PR TITLE
Layout actions are hidden right to the edge of the page wrapper.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/layout.scss
+++ b/plonetheme/onegovbear/theme/scss/layout.scss
@@ -20,6 +20,7 @@ body {
 
 #container {
   width: 100%;
+  float: left;
 }
 
 #page-wrapper {
@@ -27,7 +28,6 @@ body {
   max-width: $page-wrapper-width;
   margin: 0 auto;
   margin-bottom: 1em;
-  overflow: hidden;
 }
 
 #header {


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/749

Hiding overflow of pagewrapper caused that problem. So make container
floating left to display the service navigation in FF and IE9 as
expected in.
