### PR TITLE
Navigation is flickering during scroll to the bottom.

### DIFF
--- a/plonetheme/onegovbear/theme/index.html
+++ b/plonetheme/onegovbear/theme/index.html
@@ -76,7 +76,7 @@
           </div>
 
           <div class="row globalnavRow">
-            <div class="cell position-0 width-16">
+            <div class="cell position-0 width-16 navigation">
               <div class="fixed-header">
                 <div class="global-nav-search-wrapper">
                  <nav id="portal-globalnav-wrapper">

--- a/plonetheme/onegovbear/theme/scss/globalnav.scss
+++ b/plonetheme/onegovbear/theme/scss/globalnav.scss
@@ -17,6 +17,10 @@ $globalnav-link-font-weight: normal !default;
   globalnav-separator-width,
   globalnav-font-size);
 
+.navigation {
+  height: 52px;
+}
+
 #portal-globalnav-wrapper {
   margin-right: 0;
   float: left;


### PR DESCRIPTION
When the navigation get fixed the parent element loses its height so the
page is going to shrink. This produces the effect that the page is
flickering. So give the parent element of the navigation a fixed height
to get rid of this problem.
