### PR TITLE
Link is not recognized as a clickable element.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/servicenavigation.scss
+++ b/plonetheme/onegovbear/theme/scss/servicenavigation.scss
@@ -57,6 +57,8 @@ $service-nav-link-color: $secondary-color !default;
 
           &:hover {
             background-color: transparent;
+            text-decoration: underline;
+            color: $link-hover-color;
           }
         }
       }


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/825

Use underline text decoration for indicating a link on hover.

![bildschirmfoto 2015-10-20 um 16 50 56](https://cloud.githubusercontent.com/assets/1637820/10611088/d43e1f8e-774a-11e5-83bc-53b0d3cae8aa.png)
