### PR TITLE
Searchbox is not displayed properly over all browsers.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/search.scss
+++ b/plonetheme/onegovbear/theme/scss/search.scss
@@ -23,6 +23,7 @@ $searchbox-width: 295px;
   display: none;
   z-index: 1;
   right: 0;
+  height: 52px;
 
   @include screen-large {
     display: block;
@@ -50,7 +51,7 @@ $searchbox-width: 295px;
 
     & #searchGadget {
       width: 135px;
-      padding: .5em 35px .5em .5em;
+      padding: 9px 35px 9px 10px;
       float: right;
       box-sizing: border-box;
       &:focus{
@@ -73,7 +74,9 @@ $searchbox-width: 295px;
           visibility: visible;
       }
       input[type="text"] {
-        line-height: 20px;
+        border: none;
+        line-height: 22px;
+        height: 40px;
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/836

Especially FF does not display the searchbox in full height. So set a
fixed height for the input field and use px instead of em to force IE
using the right padding.
