### PR TITLE
Globalnav produces spacing in mobile view.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/globalnav.scss
+++ b/plonetheme/onegovbear/theme/scss/globalnav.scss
@@ -18,7 +18,9 @@ $globalnav-link-font-weight: normal !default;
   globalnav-font-size);
 
 .navigation {
-  height: 52px;
+  @include screen-large {
+    height: 52px;
+  }
 }
 
 #portal-globalnav-wrapper {


### PR DESCRIPTION
Becuase the changes in
https://github.com/OneGov/plonetheme.onegovbear/pull/76/files the
spacing also appears in the mobileview where it produces an unwanted
spacing.
