### PR TITLE
Fix css selector for listingbar

### DIFF
--- a/plonetheme/onegovbear/theme/scss/batching.scss
+++ b/plonetheme/onegovbear/theme/scss/batching.scss
@@ -1,4 +1,4 @@
-#content .listingBar, .listingBar {
+#content div.listingBar, .listingBar {
   margin: 0.5em 0;
 
   .previous {


### PR DESCRIPTION
The css selector was overridden by the ftw.theming.

Now the distance after and before the listingbar (in the example, the batching bar).
## before:

![bildschirmfoto 2015-12-04 um 09 54 58](https://cloud.githubusercontent.com/assets/557005/11585573/565eb10a-9a6d-11e5-9cee-de86b927d2e8.png)
## after:

![bildschirmfoto 2015-12-04 um 09 56 35](https://cloud.githubusercontent.com/assets/557005/11585578/601897b0-9a6d-11e5-8f1c-0ce1d560173b.png)
