### PR TITLE
Fix mobile navigation menu

### DIFF
--- a/plonetheme/onegovbear/theme/scss/menues.scss
+++ b/plonetheme/onegovbear/theme/scss/menues.scss
@@ -88,11 +88,11 @@ dl.actionMenu dt {
 }
 
 @mixin mobilemenu {
-  position: fixed;
+  position: absolute;
   right: 0;
-  top: 80px;
+  top: 34px;
   z-index: 5;
-  width: 90%;
+  width: 100%;
   margin: auto;
   cursor: default;
 


### PR DESCRIPTION
Fix mobile navigation menu:
## before:

![bildschirmfoto 2015-12-04 um 11 05 18](https://cloud.githubusercontent.com/assets/557005/11587040/16c8dd04-9a77-11e5-9461-8a8f11a6fe45.png)

![bildschirmfoto 2015-12-04 um 11 04 44](https://cloud.githubusercontent.com/assets/557005/11587038/16c6140c-9a77-11e5-9611-5fdb3a9f0a94.png)

![bildschirmfoto 2015-12-04 um 11 05 10](https://cloud.githubusercontent.com/assets/557005/11587039/16c8fc9e-9a77-11e5-8f64-b57035634c11.png)
## after:

![bildschirmfoto 2015-12-04 um 11 03 47](https://cloud.githubusercontent.com/assets/557005/11587046/2503d57c-9a77-11e5-8953-f6f54086fd83.png)

![bildschirmfoto 2015-12-04 um 11 03 54](https://cloud.githubusercontent.com/assets/557005/11587047/250463ac-9a77-11e5-8959-7859ae998ed8.png)

![bildschirmfoto 2015-12-04 um 11 04 44](https://cloud.githubusercontent.com/assets/557005/11587045/2503b8d0-9a77-11e5-88d5-bb75929b2781.png)
