### PR TITLE
Display blocks as singe portlet.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/portlets.scss
+++ b/plonetheme/onegovbear/theme/scss/portlets.scss
@@ -33,11 +33,28 @@ $portlet-column-bg-color: $gray-lighter !default;
   @include borderradius();
   padding: 1em;
   margin-bottom: 1em;
+
+  &.SimplelayoutPortlet {
+    background-color: transparent;
+    padding: 0;
+  }
+
+  .block-placeholder {
+    float: none;
+  }
+
   & .portletHeader {
     margin-bottom: 0.75em;
   }
   .sl-column > .sl-block {
     margin-bottom: 2em;
+    padding: 1em;
+    background-color: $portlet-column-bg-color;
+    box-sizing: border-box;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 }
 


### PR DESCRIPTION
![screen shot 2015-12-04 at 14 12 53](https://cloud.githubusercontent.com/assets/437933/11590518/2598ba6a-9a91-11e5-8b9c-d3f039c831e7.png)
