### PR TITLE
Implement configurable(enable/disable) pagewrapper.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.0a5 (unreleased)
 --------------------
 
+- Add pagewrapper.scss - this can be configured thru ``$showpagewrapper`` variable.
+  [mathias.leimgruber]
+
 - Add more global sections (aka tabs) scss variables.
   [kevin]
 

--- a/plonetheme/onegovbear/resources.zcml
+++ b/plonetheme/onegovbear/resources.zcml
@@ -14,6 +14,7 @@
         <theme:scss file="theme/scss/buttons.scss" />
         <theme:scss file="theme/scss/grid.scss" />
         <theme:scss file="theme/scss/layout.scss" />
+        <theme:scss file="theme/scss/pagewrapper.scss" />
         <theme:scss file="theme/scss/contacts.scss" />
         <theme:scss file="theme/scss/content.scss" />
         <theme:scss file="theme/scss/pathbar.scss" />

--- a/plonetheme/onegovbear/theme/scss/pagewrapper.scss
+++ b/plonetheme/onegovbear/theme/scss/pagewrapper.scss
@@ -1,0 +1,27 @@
+$showpagewrapper: true !default;
+$content-border-size: 1px !default;
+$content-border-style: solid !default;
+$content-border-color: transparentize($gray, 50%) !default;
+
+@include declare-variables(showpagewrapper,
+                           content-border-size,
+                           content-border-style,
+                           content-border-color);
+
+@if $showpagewrapper {
+  #page-wrapper {
+    background-color: $content-bg-color;
+
+    @include borderradius(2 * $border-radius);
+
+    border: $content-border-size $content-border-style $content-border-color;
+
+    @include boxshadow(0px 0px 4px $content-border-size transparentize($content-border-color, 20%), 0px 0px 15px 7px transparentize($content-border-color, 40%), inset 0px 0px 10px 0 transparentize($content-border-color, 30%));
+
+    #ftw-footer {
+      @include borderradius-bottom-right(2 * $border-radius - $content-border-size);
+
+      @include borderradius-bottom-left(2 * $border-radius - $content-border-size);
+    }
+  }
+}


### PR DESCRIPTION
Configurable with `$showpagewrapper`variable. It's enabled by default.

Enabled:
<img width="1314" alt="screen shot 2016-01-12 at 15 43 42" src="https://cloud.githubusercontent.com/assets/437933/12266401/4faca57a-b943-11e5-9010-bc178adb651a.png">

Disabled:
<img width="1280" alt="screen shot 2016-01-12 at 15 44 44" src="https://cloud.githubusercontent.com/assets/437933/12266434/6d69d218-b943-11e5-9c6b-1c8f136e1059.png">
