### PR TITLE
Do not display searchbox on the same height as the global section.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,9 @@ Changelog
 - Remove custom pathbar styling and template.
   [kevin]
 
+- Do not display searchbox on the same height as the global section.
+  We need more space for the global section.
+  [mathias.leimgruber]
 
 1.0.0a4 (2015-12-09)
 --------------------

--- a/plonetheme/onegovbear/theme/scss/globalnav.scss
+++ b/plonetheme/onegovbear/theme/scss/globalnav.scss
@@ -41,9 +41,6 @@ $globalnav-gutter-width: 3px !default;
     margin: 0;
     padding: 0;
     @include clearfix();
-    @include screen-large {
-      margin-right: 315px;
-    }
     > li {
       display: block;
       float: left;

--- a/plonetheme/onegovbear/theme/scss/search.scss
+++ b/plonetheme/onegovbear/theme/scss/search.scss
@@ -15,15 +15,14 @@ $searchbox-width: 295px;
 
 .portal-searchbox-wrapper{
 
-  float: left;
   width: $searchbox-width;
-  padding: 6px;
   box-sizing: border-box;
-  margin-left: -$searchbox-width;
   display: none;
   z-index: 1;
   right: 0;
   height: 52px;
+  position: absolute;
+  top: -70px;
 
   @include screen-large {
     display: block;
@@ -71,7 +70,6 @@ $searchbox-width: 295px;
           visibility: visible;
       }
       input[type="text"] {
-        border: none;
         line-height: 22px;
         height: 40px;
       }


### PR DESCRIPTION
Show the searchbox on the same height as the logo.
Also show the default input border.

![screen shot 2016-01-12 at 16 15 25](https://cloud.githubusercontent.com/assets/437933/12267669/8151cadc-b949-11e5-9411-3d52ce269005.png)
