### PR TITLE
Es adjustments

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.0a5 (unreleased)
 --------------------
 
+- Add padding for page-wrapper
+  [elioschmutz]
+
 - Hide pathbar and documentFirstHeading on the front page.
   [mathias.leimgruber]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.0a5 (unreleased)
 --------------------
 
+- Decrease upper and lower padding of logoRow.
+  [elioschmutz]
+
 - Add padding for page-wrapper
   [elioschmutz]
 

--- a/plonetheme/onegovbear/theme/scss/layout.scss
+++ b/plonetheme/onegovbear/theme/scss/layout.scss
@@ -40,7 +40,7 @@ body {
 
   .logoRow {
     box-sizing: border-box;
-    padding: 30px 0;
+    padding: 10px 0;
     > .cell {
       display: table;
     }

--- a/plonetheme/onegovbear/theme/scss/layout.scss
+++ b/plonetheme/onegovbear/theme/scss/layout.scss
@@ -28,6 +28,7 @@ body {
   max-width: $page-wrapper-width;
   margin: 0 auto;
   margin-bottom: 1em;
+  padding: .5em;
 }
 
 #header {


### PR DESCRIPTION
- Add padding for page-wrapper

Before:

![bildschirmfoto 2016-01-19 um 12 06 14](https://cloud.githubusercontent.com/assets/557005/12450499/74b4610e-bf84-11e5-953c-25e5dc68e7e8.png)

After:

![bildschirmfoto 2016-01-19 um 12 06 32](https://cloud.githubusercontent.com/assets/557005/12450501/78b65910-bf84-11e5-8350-67b559555295.png)
- Decrease upper and lower padding of logoRow.

Before:

![bildschirmfoto 2016-01-19 um 12 18 44](https://cloud.githubusercontent.com/assets/557005/12450518/9506fbec-bf84-11e5-826d-922eeeff4eb1.png)

After:

![bildschirmfoto 2016-01-19 um 12 18 58](https://cloud.githubusercontent.com/assets/557005/12450519/9507d0c6-bf84-11e5-912e-08a50eefb21f.png)
