### PR TITLE
Introduce theme variable to configure pathbar location.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 1.0.0a5 (unreleased)
 --------------------
 
+- Introduce theming variable to configure pathbar location.
+  It is possible to set the `pathbar_full_width` theme parameter in the FTI.
+  When `pathbar_full_width` is set to `python: True` the pathbar is displayed full width.
+  When `pathbar_full_width` is set to `python: False` the pathbar in the content at the top.
+
 - Decrease upper and lower padding of logoRow.
   [elioschmutz]
 

--- a/plonetheme/onegovbear/profiles/default/registry.xml
+++ b/plonetheme/onegovbear/profiles/default/registry.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<registry>
+  plone app theming interfaces IThemeSettings parameterExpressions
+  <record name="plone.app.theming.interfaces.IThemeSettings.parameterExpressions">
+    <value purge="False">
+        <element key="pathbar_full_width">python: True</element>
+    </value>
+  </record>
+</registry>

--- a/plonetheme/onegovbear/theme/rules.xml
+++ b/plonetheme/onegovbear/theme/rules.xml
@@ -85,7 +85,8 @@
     <drop css:content="#edit-bar" />
 
     <replace css:content-children="#portal-breadcrumbs" css:theme-children="#portal-breadcrumbs" />
-    <drop css:content="#portal-breadcrumbs" />
+    <drop css:content="#portal-breadcrumbs" if="$pathbar_full_width" />
+    <drop css:theme="#portal-breadcrumbs" if="$pathbar_full_width = False" />
 
     <replace css:content-children="div.documentActions" css:theme-children="#document-actions" />
     <drop css:content="div.documentActions" />

--- a/plonetheme/onegovbear/theme/scss/startpage.scss
+++ b/plonetheme/onegovbear/theme/scss/startpage.scss
@@ -3,7 +3,7 @@ body.portaltype-plone-site, body.portaltype-ftw-subsite-subsite {
     @extend .hiddenStructure;
   }
 
-  #breadcrumbs-wrapper {
+  #breadcrumbs-wrapper, #portal-breadcrumbs {
     @extend .hiddenStructure;
   }
 }

--- a/plonetheme/onegovbear/upgrades/20160120180041_define_pathbar_full_width_variable_in_registy.xml/registry.xml
+++ b/plonetheme/onegovbear/upgrades/20160120180041_define_pathbar_full_width_variable_in_registy.xml/registry.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<registry>
+  plone app theming interfaces IThemeSettings parameterExpressions
+  <record name="plone.app.theming.interfaces.IThemeSettings.parameterExpressions">
+    <value purge="False">
+        <element key="pathbar_full_width">python: True</element>
+    </value>
+  </record>
+</registry>

--- a/plonetheme/onegovbear/upgrades/20160120180041_define_pathbar_full_width_variable_in_registy.xml/upgrade.py
+++ b/plonetheme/onegovbear/upgrades/20160120180041_define_pathbar_full_width_variable_in_registy.xml/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class DefinePathbarFullWidthVariableInRegisty(UpgradeStep):
+    """Define pathbar full width variable in registy.xml.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
According to https://github.com/4teamwork/bl.web/issues/12 `bl.web` needs
a specific navigation tree styling. So we need the possibility to
display the pathbar in the content.

See http://www.sixfeetup.com/blog/how-to-use-variables-in-diazo for more information.
