### PR TITLE
Change pagewrapper behavior a little bit.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0.0a5 (unreleased)
 --------------------
 
+- Apply pagewrapper padding only to header if feature is enabled.
+  Remove pagewrapper padding for content area.
+  [mathias.leimgruber]
+
 - Introduce theming variable to configure pathbar location.
   It is possible to set the `pathbar_full_width` theme parameter in the FTI.
   When `pathbar_full_width` is set to `python: True` the pathbar is displayed full width.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.0a5 (unreleased)
 --------------------
 
+- Fix init apply of onegovbear profile. Check commit desc for details.
+  [mathias.leimgruber]
+
 - Apply pagewrapper padding only to header if feature is enabled.
   Remove pagewrapper padding for content area.
   [mathias.leimgruber]

--- a/plonetheme/onegovbear/theme/manifest.cfg
+++ b/plonetheme/onegovbear/theme/manifest.cfg
@@ -1,3 +1,7 @@
 [theme]
 title = Plone OneGov Bear Theme
 doctype = <!DOCTYPE html>
+
+
+[theme:parameters]
+pathbar_full_width = python:True

--- a/plonetheme/onegovbear/theme/scss/layout.scss
+++ b/plonetheme/onegovbear/theme/scss/layout.scss
@@ -28,7 +28,6 @@ body {
   max-width: $page-wrapper-width;
   margin: 0 auto;
   margin-bottom: 1em;
-  padding: .5em;
 }
 
 #header {

--- a/plonetheme/onegovbear/theme/scss/pagewrapper.scss
+++ b/plonetheme/onegovbear/theme/scss/pagewrapper.scss
@@ -23,5 +23,14 @@ $content-border-color: transparentize($gray, 50%) !default;
 
       @include borderradius-bottom-left(2 * $border-radius - $content-border-size);
     }
+
+    #header .logoRow {
+      padding: 10px 5px;
+    }
+
+    .portal-searchbox-wrapper {
+      padding: 5px 5px;
+    }
+
   }
 }


### PR DESCRIPTION
Before:
The generall padding added a space between global section and wrapper, and even between the editbar and the wrapper. 

![screen shot 2016-01-21 at 11 52 29](https://cloud.githubusercontent.com/assets/437933/12478703/a8343a60-c036-11e5-8fa2-3937ade9b8d1.png)

New:
Apply the padding only for the header part. imho this is better than before. 

![screen shot 2016-01-21 at 11 51 15](https://cloud.githubusercontent.com/assets/437933/12478721/d0a544c6-c036-11e5-9b48-0eb3d76e3589.png)

BTW:

The second commit fixes the policy installation, check commit desc. for details. 
