### PR TITLE
Add missing !default to font family definitions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.0a5 (unreleased)
 --------------------
 
+- Add missing !default to font family definitions.
+  [mathias.leimgruber] 
+
 - Fix init apply of onegovbear profile. Check commit desc for details.
   [mathias.leimgruber]
 

--- a/plonetheme/onegovbear/theme/scss/globals/variables.scss
+++ b/plonetheme/onegovbear/theme/scss/globals/variables.scss
@@ -1,9 +1,9 @@
 /*
   Fonts
  */
-$font-family-primary: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-$font-family-heading: $font-family-primary;
-$font-family-code: "Courier New", Courier, monospace;
+$font-family-primary: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif !default;
+$font-family-heading: $font-family-primary !default;
+$font-family-code: "Courier New", Courier, monospace !default;
 
 $color-page-background: $color-gray-light !default;
 $color-content-background: $color-white !default;


### PR DESCRIPTION
Otherwise it's not possible to redefine them in a policy.
