### PR TITLE
Add a hidden h2 to the logo markup.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0.0a5 (unreleased)
 --------------------
 
+- Add a hidden h2 to the logo markup. Without this separation the logo belongs
+  semantically to the service navigation. This confuses users with screenreaders.
+  [mathias.leimgruber]
+
 - Define styling for plone.app.multilingual based on ftw.theming.
   [Kevin Bieri]
 

--- a/plonetheme/onegovbear/theme/index.html
+++ b/plonetheme/onegovbear/theme/index.html
@@ -73,6 +73,7 @@
         <div id="header" class="clearfix">
           <div class="logoRow">
             <div>
+              <h2 class="hiddenStructure">Logo</h2>
               <a id="portal-logo" href="#"><img src="images/logo_onegov.png" alt="" /></a>
             </div>
           </div>


### PR DESCRIPTION
Without this separation the logo belongs semantically to the service navigation.

Before:

![screen shot 2016-02-03 at 11 13 07](https://cloud.githubusercontent.com/assets/437933/12779268/56957b34-ca67-11e5-9eff-c5591892de93.png)

After:

![screen shot 2016-02-03 at 11 10 37](https://cloud.githubusercontent.com/assets/437933/12779269/597904a6-ca67-11e5-9dcc-54e4b0d00890.png)
