### PR TITLE
implement uninstall profile.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0.0a5 (unreleased)
 --------------------
 
+- Implement uninstall profile. [jone]
+
 - Add a hidden h2 to the logo markup. Without this separation the logo belongs
   semantically to the service navigation. This confuses users with screenreaders.
   [mathias.leimgruber]

--- a/plonetheme/onegovbear/Extensions/install.py
+++ b/plonetheme/onegovbear/Extensions/install.py
@@ -1,0 +1,8 @@
+from Products.CMFCore.utils import getToolByName
+
+
+def uninstall(self):
+    setup_tool = getToolByName(self, 'portal_setup')
+    setup_tool.runAllImportStepsFromProfile(
+        'profile-plonetheme.onegovbear:uninstall',
+        ignore_dependencies=True)

--- a/plonetheme/onegovbear/__init__.py
+++ b/plonetheme/onegovbear/__init__.py
@@ -2,3 +2,7 @@ from zope.i18nmessageid import MessageFactory
 
 
 _ = MessageFactory('plonetheme.onegovbear')
+
+
+def initialize(context):
+    pass

--- a/plonetheme/onegovbear/configure.zcml
+++ b/plonetheme/onegovbear/configure.zcml
@@ -1,15 +1,19 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:five="http://namespaces.zope.org/five"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:profilehook="http://namespaces.zope.org/profilehook"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="plonetheme.onegovbear">
 
+    <five:registerPackage package="." initialize=".initialize" />
     <i18n:registerTranslations directory="locales"/>
 
     <include package="ftw.upgrade" file="meta.zcml" />
+    <include package="ftw.profilehook" />
     <include package="plone.app.theming" />
 
     <include file="resources.zcml" />
@@ -29,9 +33,26 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <profilehook:hook
+        profile="plonetheme.onegovbear:default"
+        handler=".hooks.installed"
+        />
+
     <upgrade-step:directory
         profile="plonetheme.onegovbear:default"
         directory="upgrades"
+        />
+
+    <genericsetup:registerProfile
+        name="uninstall"
+        title="uninstall plonetheme.onegovbear"
+        directory="profiles/uninstall"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <profilehook:hook
+        profile="plonetheme.onegovbear:uninstall"
+        handler=".hooks.uninstalled"
         />
 
 </configure>

--- a/plonetheme/onegovbear/hooks.py
+++ b/plonetheme/onegovbear/hooks.py
@@ -1,0 +1,52 @@
+from plone.app.theming.interfaces import IThemeSettings
+from plone.registry.interfaces import IRegistry
+from Products.CMFCore.utils import getToolByName
+from zope.component import getUtility
+
+
+def installed(site):
+    add_css_conditions(site)
+
+
+def uninstalled(site):
+    remove_css_conditions(site)
+    uninstall_theme_settings()
+
+
+def add_css_conditions(site):
+    for resource in getToolByName(site, 'portal_css').getResources():
+        if resource.getId() == 'members.css':
+            # See cssregistry.xml
+            continue
+
+        resource.setExpression('not:request/HTTP_X_FTW_THEMING|nothing')
+
+
+def remove_css_conditions(site):
+    portal_css = getToolByName(site, 'portal_css')
+    for resource in portal_css.getResources():
+        if resource.getExpression() == (
+                'not:request/HTTP_X_FTW_THEMING|nothing'):
+            resource.setExpression('')
+
+
+def uninstall_theme_settings():
+    settings = getUtility(IRegistry).forInterface(IThemeSettings)
+    registry = getUtility(IRegistry)
+
+    if settings.currentTheme != 'plonetheme.onegovbear':
+        return
+
+    settings.currentTheme = None
+    settings.enabled = False
+    settings.doctype = ''
+    settings.rules = None
+    settings.absolutePrefix = None
+
+    if 'pathbar_full_width' in settings.parameterExpressions:
+        del settings.parameterExpressions['pathbar_full_width']
+
+    field = registry.records['{}.parameterExpressions'.format(
+        IThemeSettings.__identifier__)]
+    if 'pathbar_full_width' in field._field.default:
+        del field._field.default['pathbar_full_width']

--- a/plonetheme/onegovbear/profiles/default/cssregistry.xml
+++ b/plonetheme/onegovbear/profiles/default/cssregistry.xml
@@ -8,25 +8,4 @@
      /-->
     <stylesheet id="member.css" enabled="False" />
 
-
-    <stylesheet id="reset.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="print.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="authoring.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="columns.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="public.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="controlpanel.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="forms.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="base.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="portlets.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="mobile.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="IEFixes.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="++resource++plone.app.discussion.stylesheets/discussion.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="deprecated.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="navtree.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="invisibles.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="ploneCustom.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="++resource++plone.app.jquerytools.overlays.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="++resource++plone.formwidget.contenttree/contenttree.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-    <stylesheet id="++resource++tinymce.stylesheets/tinymce.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
-
 </object>

--- a/plonetheme/onegovbear/profiles/default/registry.xml
+++ b/plonetheme/onegovbear/profiles/default/registry.xml
@@ -3,7 +3,7 @@
   plone app theming interfaces IThemeSettings parameterExpressions
   <record name="plone.app.theming.interfaces.IThemeSettings.parameterExpressions">
     <value purge="False">
-        <element key="pathbar_full_width">python: True</element>
+        <element key="pathbar_full_width">python:True</element>
     </value>
   </record>
 </registry>

--- a/plonetheme/onegovbear/profiles/uninstall/actions.xml
+++ b/plonetheme/onegovbear/profiles/uninstall/actions.xml
@@ -1,0 +1,9 @@
+<object meta_type="Plone Actions Tool"
+        name="portal_actions"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <object name="site_actions" meta_type="CMF Action Category">
+        <object name="customize_design" meta_type="CMF Action" remove="True" />
+    </object>
+
+</object>

--- a/plonetheme/onegovbear/profiles/uninstall/browserlayer.xml
+++ b/plonetheme/onegovbear/profiles/uninstall/browserlayer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<layers>
+
+    <layer name="plonetheme.onegovbear" remove="True" />
+
+</layers>

--- a/plonetheme/onegovbear/profiles/uninstall/cssregistry.xml
+++ b/plonetheme/onegovbear/profiles/uninstall/cssregistry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<object name="portal_css">
+
+    <stylesheet
+        id="member.css"
+        enabled="1" />
+
+    <stylesheet
+        id="RTL.css"
+        expression="python:portal.restrictedTraverse('@@plone_portal_state').is_rtl()" />
+
+</object>

--- a/plonetheme/onegovbear/profiles/uninstall/tinymce.xml
+++ b/plonetheme/onegovbear/profiles/uninstall/tinymce.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object>
+    <layout>
+        <content_css value="" />
+    </layout>
+</object>

--- a/plonetheme/onegovbear/tests/test_uninstall.py
+++ b/plonetheme/onegovbear/tests/test_uninstall.py
@@ -1,0 +1,8 @@
+from ftw.testing.genericsetup import apply_generic_setup_layer
+from ftw.testing.genericsetup import GenericSetupUninstallMixin
+from unittest2 import TestCase
+
+
+@apply_generic_setup_layer
+class TestGenericSetupUninstall(TestCase, GenericSetupUninstallMixin):
+    package = 'plonetheme.onegovbear'

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ version = '1.0.0a5.dev0'
 tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
+    'ftw.testing',
     'plone.app.testing',
     'unittest2',
     ]
@@ -37,11 +38,12 @@ setup(name='plonetheme.onegovbear',
       zip_safe=False,
 
       install_requires=[
+          'ftw.profilehook',
           'ftw.theming',
           'ftw.upgrade',
-          'plone.directives.form',
           'plone.api',
           'plone.app.theming',
+          'plone.directives.form',
           'setuptools',
           'z3c.jbot',
       ],


### PR DESCRIPTION
- Theme can not be uninstalled, therefore we need to cleanup the registry.
- Move CSS conditions to hooks, so that we do not implictly register new CSS resources.
