### PR TITLE
Move heading above nav element to indicate globalnavigation.

### DIFF
--- a/plonetheme/onegovbear/theme/rules.xml
+++ b/plonetheme/onegovbear/theme/rules.xml
@@ -102,11 +102,6 @@
     <replace css:theme="#accesskeys" css:content="#accesskeys" />
 
     <!-- Move hidden titles from accesskeys viewlet to place, where they belong -->
-    <drop css:content="#hidden_content_navigation_title" />
-    <before css:theme="#column-navigation">
-        <xsl:copy-of css:select="#hidden_content_navigation_title"/>
-    </before>
-
     <drop css:content="#hidden_further_infos_title" />
     <before css:theme="#column-sidebar">
         <xsl:copy-of css:select="#hidden_further_infos_title"/>

--- a/plonetheme/onegovbear/theme/rules.xml
+++ b/plonetheme/onegovbear/theme/rules.xml
@@ -70,7 +70,8 @@
 
     <replace css:content="#portal-globalnav" css:theme="#portal-globalnav" />
     <!-- Move hidden h2 of global section too -->
-    <before css:content="#portal-header > h2.hiddenStructure" css:theme="#portal-globalnav"/>
+    <before css:content="#globalnav-selected" css:theme="#portal-globalnav"/>
+    <before css:content="#globalnav-heading" css:theme="#portal-globalnav-wrapper"/>
 
     <replace css:content="#portal-searchbox" css:theme="#portal-searchbox" />
     <replace css:content="#portal-personaltools-wrapper" css:theme="#portal-personaltools-wrapper" />

--- a/plonetheme/onegovbear/viewlets/accesskeys.pt
+++ b/plonetheme/onegovbear/viewlets/accesskeys.pt
@@ -7,10 +7,6 @@
         Navigation on <span i18n:name="title" tal:replace="view/nav_root_title" />
     </h1>
 
-    <h1 id="hidden_content_navigation_title"
-        i18n:translate=""
-        class="hiddenStructure">Content navigation</h1>
-
     <h1 class="hiddenStructure"
         id="hidden_further_infos_title"
         i18n:translate="">Further informations</h1>


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/1059

According to access4all each `nav` element must have a heading.
