### PR TITLE
Fix side effect with hiding search button (livesearch/detailsearch).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix side effect with hiding search button (livesearch/detailsearch).
+  Accidentally the searchButton of the contenttree widget was hidden by the last bern.web 2.0 release.
+  [mathias.leimgruber]
 
 
 1.1.0 (2016-04-11)

--- a/plonetheme/onegovbear/theme/scss/search.scss
+++ b/plonetheme/onegovbear/theme/scss/search.scss
@@ -41,7 +41,7 @@ $searchbox-width: 295px;
     }
 
     & input.searchButton {
-      display: none;
+      @include hidden-structure();
     }
 
     & #searchGadget {
@@ -98,7 +98,8 @@ $searchbox-width: 295px;
   }
 }
 
-.searchButton {
+
+#searchform .searchButton {
   @include hidden-structure();
 }
 


### PR DESCRIPTION
Accidentally the searchButton of the contenttree widget was hidden by the last bern.web 2.0 release.
