### PR TITLE
Remove horizontal scrollbar in IE.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
+- Remove horizontal scrollbar in IE.
+  [Kevin Bieri]
+
 - Improve simplelayout styles (Dragging new layout + Simplelayout Porlet).
   [mathias.leimgruber]
 

--- a/plonetheme/onegovbear/theme/index.html
+++ b/plonetheme/onegovbear/theme/index.html
@@ -343,9 +343,6 @@
         </div>
 
       </div>
-      <div id="bottom-actions">
-        <ul id="portal-siteactions" />
-      </div>
 
       <!-- closes #container -->
     </div>


### PR DESCRIPTION
The bottom actions produce a horizontal scrollbar in IE.
So remove the bottoms actions from the index.html because we do not
display any site-actions anyway.
