### PR TITLE
Add text to zoom buttons, since wcag 2.0 doesn't allow empty links.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
+- Add text to zoom buttons, since wcag 2.0 doesn't allow empty links.
+  [mathias.leimgruber]
+
 - Remove horizontal scrollbar in IE.
   [Kevin Bieri]
 

--- a/plonetheme/onegovbear/theme/index.html
+++ b/plonetheme/onegovbear/theme/index.html
@@ -67,9 +67,9 @@
       </div>
 
       <ul class="zoom-buttons">
-        <li><a href="#" class="zoom-button" data-zoom-level="1" id="zoom-small"></a></li>
-        <li><a href="#" class="zoom-button" data-zoom-level="1.1" id="zoom-medium"></a></li>
-        <li><a href="#" class="zoom-button" data-zoom-level="1.3" id="zoom-large"></a></li>
+        <li><a href="#" class="zoom-button" data-zoom-level="1" id="zoom-small">Normale Schriftgr&ouml;sse</a></li>
+        <li><a href="#" class="zoom-button" data-zoom-level="1.1" id="zoom-medium">Mittlere Schriftgr&ouml;sse</a></li>
+        <li><a href="#" class="zoom-button" data-zoom-level="1.3" id="zoom-large">Grosse Schriftgr&ouml;sse</a></li>
       </ul>
 
     </div>

--- a/plonetheme/onegovbear/theme/scss/portaltop.scss
+++ b/plonetheme/onegovbear/theme/scss/portaltop.scss
@@ -28,6 +28,7 @@ $portal-top-bg-color: $page-bg-color !default;
   float: left;
   margin-left: 2em;
   display: none;
+  height: 0;
 
   > li {
     display: inline-block;
@@ -35,21 +36,26 @@ $portal-top-bg-color: $page-bg-color !default;
     > a {
       padding: 0;
       padding-right: .2em;
+      width: 0.7em;
+      display: block;
+      height: 0
     }
   }
 }
 
 .zoom-button {
-  color: $text-color;
-
-  &:hover {
-    color: $text-color;
-    text-decoration: none;
-  }
+  color: transparent;
 
   &:before {
     content: "A";
+    color: $text-color;
   }
+
+  &:hover {
+    color: transparent;
+    text-decoration: none;
+  }
+
 }
 
 #zoom-small {

--- a/plonetheme/onegovbear/viewlets/mobile_logo.pt
+++ b/plonetheme/onegovbear/viewlets/mobile_logo.pt
@@ -5,5 +5,6 @@
                    title view/navigation_root_title"
    i18n:domain="plone"
    i18n:attributes="title">
-    <img tal:attributes="src string:${view/navigation_root_url}/mobile_logo.png">
+    <img tal:attributes="src string:${view/navigation_root_url}/mobile_logo.png;
+                         alt python:here.portal_url.getPortalObject().getProperty('logo_alt_text', '')">
 </a>


### PR DESCRIPTION
<img width="744" alt="screen shot 2016-06-21 at 15 26 19" src="https://cloud.githubusercontent.com/assets/437933/16231022/8a788fe8-37c4-11e6-86e7-dbeaee57129e.png">

This PR also adds a alt text to the mobile logo if `logo_alt_text` is available (WCGA 2.0 compatibility). 
