### PR TITLE
Fix left margin of external link

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix left margin of external-site icon
+  [raphael-s]
 
 
 1.3.0 (2016-11-07)

--- a/plonetheme/onegovbear/theme/scss/iconset.scss
+++ b/plonetheme/onegovbear/theme/scss/iconset.scss
@@ -58,6 +58,7 @@
       -ms-transform: rotate(45deg);
       -webkit-transform: rotate(45deg);
       margin-right: -0.35em;
+      margin-left: -0.1em;
     }
   }
 }


### PR DESCRIPTION
Closes the gap between the link and the external-link icon. 
See: https://github.com/4teamwork/bern.web/issues/1030

Now it looks like this:
<img width="516" alt="screen shot 2016-10-12 at 15 43 31" src="https://cloud.githubusercontent.com/assets/16755391/19312451/abc4bad8-9092-11e6-86bd-c55ed7a9a8b0.png">

closes https://github.com/4teamwork/bern.web/issues/1030
