### PR TITLE
Remove subsite dependency from pathbar viewlet

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove subsite support from pathbar viewlet since we removed the
+  subsite dependency from this package.
+  [raphael-s]
 
 
 1.3.1 (2016-11-09)

--- a/plonetheme/onegovbear/viewlets/pathbar.pt
+++ b/plonetheme/onegovbear/viewlets/pathbar.pt
@@ -8,13 +8,9 @@
     </h2>
 
     <ul>
-        <li id="breadcrumbs-home" tal:define="subsite view/get_subsite">
-          <a i18n:translate="tabs_home" tal:condition="not: subsite"
+        <li id="breadcrumbs-home">
+          <a i18n:translate="tabs_home"
              tal:attributes="href view/navigation_root_url">Home</a>
-
-          <a tal:condition="subsite"
-             tal:attributes="href subsite/url"
-             tal:content="subsite/title">Subsite title</a>
 
           <span tal:condition="breadcrumbs" class="breadcrumbSeparator">/</span>
         </li>

--- a/plonetheme/onegovbear/viewlets/pathbar.py
+++ b/plonetheme/onegovbear/viewlets/pathbar.py
@@ -1,5 +1,3 @@
-from ftw.subsite.interfaces import ISubsite
-from plone import api
 from plone.app.layout.viewlets import common
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
@@ -9,11 +7,3 @@ class PathBarViewlet(common.PathBarViewlet):
 
     def index(self):
         return self.pathbar()
-
-    def get_subsite(self):
-        nav_root = api.portal.get_navigation_root(self.context)
-        if ISubsite.providedBy(nav_root):
-            return dict(title=nav_root.Title(),
-                        url=nav_root.absolute_url())
-        else:
-            return None


### PR DESCRIPTION
Since this package no longer has a dependeny on `ftw.subsite` we can remove the support of subsites from the pathbar viewlet. 

closes #145 