### PR TITLE
Fix content tree widget.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Move buttons of content tree widget so they no longer hide
+  the last item. [mbaechtold]
 
 
 1.3.1 (2016-11-09)

--- a/plonetheme/onegovbear/theme/scss/formwidget-contenttree.scss
+++ b/plonetheme/onegovbear/theme/scss/formwidget-contenttree.scss
@@ -18,7 +18,7 @@
 
   .contenttreeWindowActions {
     position: absolute;
-    bottom: 2em;
+    bottom: 0;
   }
 }
 


### PR DESCRIPTION
The buttons on the bottom of the content tree widget used to hide the last item.

See https://extranet.4teamwork.ch/support/bern.ch/tracker-www-bern.ch/884 for more information.

## Before

<img width="1440" alt="screenshot vorher" src="https://cloud.githubusercontent.com/assets/28220/24895760/5b13f412-1e92-11e7-8519-7cf45d032298.png">

## After

<img width="1440" alt="screenshot nachher" src="https://cloud.githubusercontent.com/assets/28220/24895767/6097dd90-1e92-11e7-9a83-23ae136aa9bb.png">


