### PR TITLE
Hide the additional logo if the class ".hide" is present.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
+- Hide the additional logo if the class ".hide" is present (only for mobile
+  screens). [mbaechtold]
+
 - Fix label of form field used to set the footer background
   color. [mbaechtold]
 

--- a/plonetheme/onegovbear/theme/scss/additionallogo.scss
+++ b/plonetheme/onegovbear/theme/scss/additionallogo.scss
@@ -2,6 +2,13 @@
 
   float: right;
 
+  &.hide {
+    visibility: hidden;
+    @include screen-small {
+      visibility: visible;
+    }
+  }
+
   img {
     max-height: 50px;
     width: auto;


### PR DESCRIPTION
This applies to mobile screens only. The class may be set through JavaScript in the policy.

Partially closes https://github.com/4teamwork/bern.web/issues/1209