### PR TITLE
Add dependency for ftw.subsite

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
+- Add dependency for ftw.subsite because the pathbar viewlet doesn't work
+  without this package installed. [raphael-s]
+
 - Hide the additional logo if the class ".hide" is present (only for mobile
   screens). [mbaechtold]
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name='plonetheme.onegovbear',
       install_requires=[
           'ftw.theming',
           'ftw.upgrade',
+          'ftw.subsite',  # required because of pathbar viewlet
           'plone.directives.form',
           'plone.api',
           'plone.app.theming',


### PR DESCRIPTION
Adds a dependency for `ftw.subsite` because the pathbar viewlet doesn't work when this package is not installed.

closes #145 