### PR TITLE
Remove additional spacing underneath the additional logo on subsites.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/pathbar.scss
+++ b/plonetheme/onegovbear/theme/scss/pathbar.scss
@@ -7,7 +7,9 @@ $pathbar-font-weight: normal !default;
 
 .template-startpage #breadcrumbs-wrapper,
 body.portaltype-ftw-subsite-subsite #breadcrumbs-wrapper {
-  margin-top: 2em;
+  @include screen-small {
+    margin-top: 2em;
+  }
 }
 
 body.portaltype-plone-site,


### PR DESCRIPTION
Closes https://github.com/4teamwork/bern.web/issues/1214

# Before
<img width="432" alt="screen shot 2017-04-21 at 16 53 00" src="https://cloud.githubusercontent.com/assets/1637820/25283206/45b0452a-26b3-11e7-949b-c31567cfc852.png">

# After
<img width="434" alt="screen shot 2017-04-21 at 16 53 17" src="https://cloud.githubusercontent.com/assets/1637820/25283218/4b4f104c-26b3-11e7-833d-c1bb7972f2c2.png">
