### PR TITLE
Remove superfluous margin of textblock.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- Remove superfluous margin of textblock. [mbaechtold]
+
 - Enable selection of navigation access key. [mbaechtold]
 
 

--- a/plonetheme/onegovbear/theme/scss/typography.scss
+++ b/plonetheme/onegovbear/theme/scss/typography.scss
@@ -43,9 +43,6 @@ p {
       margin-left:1em;
     }
   }
-  img {
-    margin-bottom: 1em;
-  }
   ul, ol {
     margin-left: 0;
     padding-left: 20px;


### PR DESCRIPTION
Until now the margin was doubled when a more recent version of "ftw.simplelayout" is used, because "ftw.simplelayout" also adds some margin.