### PR TITLE
Fix zoom button placement on android browser.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/portaltop.scss
+++ b/plonetheme/onegovbear/theme/scss/portaltop.scss
@@ -37,13 +37,14 @@ $portal-top-bg-color: $page-bg-color !default;
 
   > li {
     display: inline-block;
+    vertical-align: text-top;
     float: none;
     > a {
       padding: 0;
       padding-right: .2em;
       width: 0.7em;
       display: block;
-      height: 0
+      height: 0;
     }
   }
 }


### PR DESCRIPTION
Current state of zoom buttons:
![screen shot 2017-08-02 at 14 00 40](https://user-images.githubusercontent.com/1375745/28872810-20209ea8-778b-11e7-9c59-076aece51ac0.png)

Placement after fix:
![screen shot 2017-08-02 at 14 01 15](https://user-images.githubusercontent.com/1375745/28872818-273164a2-778b-11e7-959a-c25f09ea7dfa.png)

The zoom buttons are strangely styled with `height: 0;` and `:before` elements with the actual content. This PR does not touch this and only fixes the display of the zoom buttons on android tablets.