### PR TITLE
Limit width of sl image with link on IE11.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/simplelayout.scss
+++ b/plonetheme/onegovbear/theme/scss/simplelayout.scss
@@ -173,3 +173,7 @@ ul[class^="sl-toolbar"] {
 .icons-on .sl-image .colorboxLink:before{
   margin-bottom: 1em;
 }
+
+.sl-image .imageContainer > a {
+  max-width: 100%;
+}


### PR DESCRIPTION
I checked and this happens only on Bern, not in `ftw.simplelayout`.

Fixes https://github.com/4teamwork/bern.web/issues/1291