### PR TITLE
No longer open overlay on mobile devices (phone).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- No longer open overlay on mobile devices (phone). [mathias.leimgruber]
+
 - Remove superfluous margin of textblock. [mbaechtold]
 
 - Remove min-height on sl-column. the simplelayout.scss already does this for us. [mathias.leimgruber]

--- a/plonetheme/onegovbear/theme/scss/simplelayout.scss
+++ b/plonetheme/onegovbear/theme/scss/simplelayout.scss
@@ -170,8 +170,21 @@ ul[class^="sl-toolbar"] {
   }
 }
 
-.icons-on .sl-image .colorboxLink:before{
-  margin-bottom: 1em;
+.icons-on .sl-simplelayout .sl-block-content .colorboxLink {
+  pointer-events: none;
+
+  @include screen-medium() {
+    pointer-events: auto;
+  }
+
+  &:before{
+    margin-bottom: 1em;
+    display: none;
+
+    @include screen-medium() {
+      display: block;
+    }
+  }
 }
 
 .sl-image .imageContainer > a {


### PR DESCRIPTION
![overlay](https://user-images.githubusercontent.com/437933/29773834-616bebc8-8bff-11e7-948f-8a5c177fc541.gif)
