### PR TITLE
Fix search position on mobile devices after scrolling.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- Fix search position on mobile devices after scrolling. [mathias.leimgruber]
+
 - No longer open overlay on mobile devices (phone). [mathias.leimgruber]
 
 - Remove superfluous margin of textblock. [mbaechtold]

--- a/plonetheme/onegovbear/theme/scss/search.scss
+++ b/plonetheme/onegovbear/theme/scss/search.scss
@@ -8,7 +8,7 @@ $searchbox-width: 295px;
   $searchbox-width);
 
 
-.portal-searchbox-wrapper{
+.portal-searchbox-wrapper {
 
   float: left;
   width: $searchbox-width;
@@ -19,6 +19,13 @@ $searchbox-width: 295px;
   z-index: 1;
   right: 0;
   height: 52px;
+  top: 54px;
+
+  @include screen-small {
+    &.open {
+      top: -166px;
+    }
+  }
 
   @include screen-large {
     display: block;
@@ -30,7 +37,7 @@ $searchbox-width: 295px;
 
   &.open {
     display: block;
-    position: fixed;
+    position: absolute;
     margin-left: 0;
   }
 


### PR DESCRIPTION
position fixes was not a good solution, since it's possible to scroll down 😄 

It's now absolut positioned, with a negativ top value, since the searchbox is rendered below the logo. 
![search](https://user-images.githubusercontent.com/437933/29823365-b9739c9c-8cce-11e7-94fc-d1218d7a3dd3.gif)
