### PR TITLE
Fix buildout.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -4,6 +4,3 @@ extends =
     sources.cfg
 
 package-name = plonetheme.onegovbear
-
-[versions]
-six = 1.9.0


### PR DESCRIPTION
By removing the version pinning of "six", we may solve an error occurring when `bin/buildout` is run:

> Error: The requirement ('six>=1.12.0') is not allowed by your [versions] constraint (1.9.0)

See https://github.com/OneGov/plonetheme.onegovbear/issues/163 for the entire traceback.

The pinning was introduced in https://github.com/OneGov/plonetheme.onegovbear/pull/71/, unfortunately no reason was given for the change.

Closes https://github.com/OneGov/plonetheme.onegovbear/issues/163