### PR TITLE
Calendar portlet fixes for dnd dashboard

### DIFF
--- a/plonetheme/onegovbear/browser/z3cjbot/plone.app.event.portlets.portlet_calendar.pt
+++ b/plonetheme/onegovbear/browser/z3cjbot/plone.app.event.portlets.portlet_calendar.pt
@@ -1,0 +1,83 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="plone"
+      tal:omit-tag="">
+<dl class="portlet portletCalendar"
+    tal:define="navigation_root_url context/@@plone_portal_state/navigation_root_url;
+                month view/month;
+                year view/year;">
+
+    <dt class="portletHeader">
+      <span class="portletTopLeft"></span>
+      <a href="#" rel="nofollow"
+           class="calendarPrevious"
+           title="Previous month"
+           tal:define="prev_month view/prev_month;
+                       prev_year view/prev_year"
+           tal:attributes="href view/prev_query;
+                           data-year prev_year;
+                           data-month prev_month;"
+           i18n:attributes="title title_previous_month;">&laquo;</a>
+
+        <span i18n:translate="" tal:omit-tag="">
+            <span i18n:name="monthname" i18n:translate=""
+                  tal:content="view/month_name"
+                  tal:omit-tag="">monthname</span>
+            <span i18n:name="year" i18n:translate=""
+                  tal:content="year"
+                  tal:omit-tag="">year</span>
+        </span>
+
+        <a href="#" rel="nofollow"
+           class="calendarNext"
+           title="Next month"
+           tal:define="next_month view/next_month;
+                       next_year view/next_year"
+           tal:attributes="href view/next_query;
+                           data-year next_year;
+                           data-month next_month;"
+           i18n:attributes="title title_next_month;">&raquo;</a>
+        <span class="portletTopRight"></span>
+    </dt>
+
+    <dd class="portletItem">
+        <table class="ploneCalendar" summary="Calendar"
+            i18n:attributes="summary summary_calendar">
+            <caption class="hiddenStructure"
+                i18n:translate="" tal:content="string:month-${month}">monthname</caption>
+            <thead>
+              <tr class="weekdays"><tal:data repeat="weekday view/weekdays">
+                <th scope="col" i18n:translate="" tal:content="weekday">Su</th>
+              </tal:data></tr>
+            </thead>
+            <tbody>
+              <tr tal:repeat="week view/cal_data">
+                <tal:block repeat="day week">
+                <td class="event"
+                  tal:define="today day/today;
+                              next_month day/next_month;
+                              prev_month day/prev_month;
+                              events day/events;
+                              limit python:len(events) if events is not None else 0"
+                  tal:attributes="class python:u'event%s%s%s%s' %
+                              ((today and ' today' or ''),
+                              (next_month and ' cal_next_month' or ''),
+                              (prev_month and ' cal_prev_month' or ''),
+                              (events and ' cal_has_events' or ''))">
+                    <a href=""
+                      tal:omit-tag="not:events"
+                      tal:attributes="href python:view.date_events_url(day['date_string']);
+                                      title day/events_string;"
+                      tal:content="day/day">31</a>
+
+                </td>
+                </tal:block>
+              </tr>
+            </tbody>
+        </table>
+        <span class="portletBottomLeft"></span>
+        <span class="portletBottomRight"></span>
+    </dd>
+</dl>
+</html>

--- a/plonetheme/onegovbear/browser/z3cjbot/plone.app.event.portlets.portlet_calendar.pt
+++ b/plonetheme/onegovbear/browser/z3cjbot/plone.app.event.portlets.portlet_calendar.pt
@@ -10,6 +10,9 @@
 
     <dt class="portletHeader">
       <span class="portletTopLeft"></span>
+
+      <div class="title" i18n:domain="plone" i18n:translate="summary_calendar">Calendar</div>
+
       <a href="#" rel="nofollow"
            class="calendarPrevious"
            title="Previous month"

--- a/plonetheme/onegovbear/theme/scss/portlet-calendar.scss
+++ b/plonetheme/onegovbear/theme/scss/portlet-calendar.scss
@@ -6,7 +6,6 @@ $calendar-portlet-bg-color: $portlet-column-bg-color !default;
 
 .portletCalendar {
   width: auto;
-  margin: 1px 0 1em 0;
   dt {
     background-color: $calendar-portlet-bg-color;
     font-weight: bold;


### PR DESCRIPTION
Vertically align Calendar portlet with other portlets for dashboard / startpage

Add title to Calendar portlet so portlet actions on drag n drop dashboard don't hide the net month link

Before
<img width="270" alt="Screenshot 2020-05-01 at 17 35 57" src="https://user-images.githubusercontent.com/54800639/80818136-f64f3300-8bd2-11ea-809c-673f34663ff4.png">


After

<img width="270" alt="Screenshot 2020-05-01 at 17 41 55" src="https://user-images.githubusercontent.com/54800639/80818234-167ef200-8bd3-11ea-9e13-89d01c1d7295.png">
