### PR TITLE
Show name beneath image in contact block.

### DIFF
--- a/plonetheme/onegovbear/theme/scss/contacts.scss
+++ b/plonetheme/onegovbear/theme/scss/contacts.scss
@@ -11,3 +11,8 @@
         margin-top: 12px;
     }
 }
+
+.ftw-contacts-memberblock .sl-block-content {
+    display: flex;
+    flex-direction: column;
+}


### PR DESCRIPTION
When the name is short it would not wrap beneath the image. With the fix it will always wrap.